### PR TITLE
Specify plpgsql language for policy reset

### DIFF
--- a/supabase/migrations/20250914103012_late_glitter.sql
+++ b/supabase/migrations/20250914103012_late_glitter.sql
@@ -12,7 +12,7 @@ begin
   loop
     execute format('drop policy if exists %I on public.analytics_events;', r.policyname);
   end loop;
-end $$;
+end $$ language plpgsql;
 
 -- 2) Make sure roles have required privileges (RLS needs BOTH privilege + policy)
 grant usage on schema public to anon, authenticated;


### PR DESCRIPTION
## Summary
- ensure analytics_events policy reset uses plpgsql

## Testing
- `npm run lint` *(fails: Unexpected any and require import warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c69d1136148328a4342c9d90122885