### PR TITLE
Fix Apps Script constant name and remove markdown fences

### DIFF
--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -1,6 +1,5 @@
-```javascript
 // Replace with your actual Google Sheet ID
-const SPREADSHEHEET_ID = "YOUR_SPREADSHEET_ID_HERE"; 
+const SPREADSHEET_ID = "YOUR_SPREADSHEET_ID_HERE";
 const SHEET_NAME = "Raw Data";
 
 function doPost(e) {
@@ -190,4 +189,3 @@ function doOptions(e) {
     .createTextOutput('')
     .setMimeType(ContentService.MimeType.TEXT);
 }
-```


### PR DESCRIPTION
## Summary
- rename the Apps Script spreadsheet constant to match its usage
- remove the surrounding Markdown code fences so the file is valid JavaScript

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d2820bbd8883288e20ee87f9f04d2f