### PR TITLE
Adjust Google Sheets request to avoid preflight

### DIFF
--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -7,10 +7,13 @@ function doPost(e) {
   try {
     // Debug logging - log the raw incoming data
     Logger.log('Raw incoming data: ' + JSON.stringify(e.postData.contents));
-    
+
     // Parse the incoming JSON data
     const requestData = JSON.parse(e.postData.contents);
-    
+    // Note: Clients must send a simple POST request (no preflight) because Apps Script web apps
+    // only surface doPost/doGet handlers. Browsers will otherwise attempt an OPTIONS preflight
+    // that the web app cannot respond to, resulting in 405 errors before reaching this code.
+
     // Debug logging - log the parsed data and type
     Logger.log('Parsed requestData: ' + JSON.stringify(requestData));
     Logger.log('Received type: ' + requestData.type);

--- a/src/lib/dataCapture.ts
+++ b/src/lib/dataCapture.ts
@@ -198,8 +198,9 @@ class OnlineDataCapture {
     try {
       const response = await fetch(sheetsUrl, {
         method: 'POST',
+        // Use a simple request so Apps Script receives the POST directly without a preflight.
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'text/plain;charset=UTF-8',
         },
         body: JSON.stringify(payload)
       });


### PR DESCRIPTION
## Summary
- switch the Google Sheets fetch to use a simple POST content type to avoid preflight requests
- document in the Apps Script handler that clients must send simple POSTs because only doPost/doGet are supported

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68d2873e1cd4832886aa3d268ee69782