### PR TITLE
Handle lead and bonus submission failures

### DIFF
--- a/src/pages/Bonuses.tsx
+++ b/src/pages/Bonuses.tsx
@@ -59,31 +59,44 @@ export default function Bonuses() {
 
     // Track form submission
     analytics.trackFormStart('bonus_signup');
-    analytics.trackFormSubmission('bonus_signup', { email }, true);
 
     // Capture bonus signup online
-    console.log('🎁 About to capture bonus signup with dataCapture.captureBonusSignup...');
-    const signup = await dataCapture.captureBonusSignup(email, 'bonus_page');
-    console.log('🎁 Bonus signup captured:', signup);
-    localStorage.setItem('bonuses_unlocked', email);
-    setIsUnlocked(true);
-    setHasSubmitted(true);
+    try {
+      console.log('🎁 About to capture bonus signup with dataCapture.captureBonusSignup...');
+      const signup = await dataCapture.captureBonusSignup(email, 'bonus_page');
+      console.log('🎁 Bonus signup captured:', signup);
 
-    // Set user ID for analytics
-    analytics.setUserId(signup.id);
+      analytics.trackFormSubmission('bonus_signup', { email }, true);
+      localStorage.setItem('bonuses_unlocked', email);
+      setIsUnlocked(true);
+      setHasSubmitted(true);
 
-    // Track bonus unlock
-    analytics.trackBonusUnlock(email);
+      // Set user ID for analytics
+      analytics.setUserId(signup.id);
 
-    // Track user journey
-    analytics.trackUserJourney('bonuses_unlocked', { 
-      signupId: signup.id 
-    });
+      // Track bonus unlock
+      analytics.trackBonusUnlock(email);
 
-    toast({
-      title: "Success!",
-      description: "Your bonus materials have been unlocked. Click any item to download.",
-    });
+      // Track user journey
+      analytics.trackUserJourney('bonuses_unlocked', {
+        signupId: signup.id
+      });
+
+      toast({
+        title: "Success!",
+        description: "Your bonus materials have been unlocked. Click any item to download.",
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('❌ Failed to capture bonus signup:', error);
+      analytics.trackFormSubmission('bonus_signup', { email }, false);
+      analytics.trackError(`Bonus signup failed: ${errorMessage}`, 'bonus_signup');
+      toast({
+        title: "Submission Failed",
+        description: "We couldn't unlock your bonuses. Please try again.",
+        variant: "destructive",
+      });
+    }
   };
 
   // Removed handleDownload function - no longer needed

--- a/src/pages/TestPackages.tsx
+++ b/src/pages/TestPackages.tsx
@@ -143,44 +143,58 @@ export default function TestPackages() {
 
     // Track form submission attempt
     analytics.trackFormStart('package_order');
-    analytics.trackFormSubmission('package_order', formData, true);
 
     // Capture lead data online
-    console.log('📝 About to capture lead with dataCapture.captureLead...');
-    const lead = await dataCapture.captureLead({
-      firstName: formData.firstName,
-      lastName: formData.lastName,
-      email: formData.email,
-      phone: formData.phone,
-      packageBought: selectedPackage?.title || 'unknown',
-      gradeSelected: formData.package,
-      source: 'test_package'
-    });
-    console.log('📝 Lead captured:', lead);
+    try {
+      console.log('📝 About to capture lead with dataCapture.captureLead...');
+      const lead = await dataCapture.captureLead({
+        firstName: formData.firstName,
+        lastName: formData.lastName,
+        email: formData.email,
+        phone: formData.phone,
+        packageBought: selectedPackage?.title || 'unknown',
+        gradeSelected: formData.package,
+        source: 'test_package'
+      });
+      console.log('📝 Lead captured:', lead);
 
-    // Set user ID for analytics
-    analytics.setUserId(lead.id);
+      analytics.trackFormSubmission('package_order', formData, true);
 
-    // Track purchase completion
-    analytics.trackPurchaseComplete({
-      ...lead,
-      price: selectedPackage?.price
-    });
+      // Set user ID for analytics
+      analytics.setUserId(lead.id);
 
-    // Track user journey
-    analytics.trackUserJourney('purchase_completed', {
-      packageId: selectedPackage?.id,
-      price: selectedPackage?.price
-    });
+      // Track purchase completion
+      analytics.trackPurchaseComplete({
+        ...lead,
+        price: selectedPackage?.price
+      });
 
-    // Navigate to thank you page
-    navigate('/thank-you', { 
-      state: { 
-        name: formData.firstName,
-        package: selectedPackage?.title,
-        grade: selectedPackage?.grade
-      } 
-    });
+      // Track user journey
+      analytics.trackUserJourney('purchase_completed', {
+        packageId: selectedPackage?.id,
+        price: selectedPackage?.price
+      });
+
+      // Navigate to thank you page
+      navigate('/thank-you', {
+        state: {
+          name: formData.firstName,
+          package: selectedPackage?.title,
+          grade: selectedPackage?.grade
+        }
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('❌ Failed to capture lead submission:', error);
+      analytics.trackFormSubmission('package_order', formData, false);
+      analytics.trackError(`Lead capture failed: ${errorMessage}`, 'test_packages');
+      toast({
+        title: 'Submission Failed',
+        description: 'We were unable to submit your information. Please try again.',
+        variant: 'destructive'
+      });
+      return;
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- guard the test package lead submission against capture failures with an error toast and telemetry
- keep the bonus signup form open if capture fails while surfacing an error toast and analytics signal

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d28ea7d4b08328968ee693e0156964