### PR TITLE
Improve Supabase persistence for data capture

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -25,6 +25,8 @@ export interface LeadRecord {
   grade_selected: string;
   source?: string;
   session_id?: string;
+  page_url?: string;
+  user_agent?: string;
   created_at?: string;
 }
 
@@ -32,6 +34,9 @@ export interface BonusSignupRecord {
   id?: string;
   email: string;
   session_id?: string;
+  source?: string;
+  page_url?: string;
+  user_agent?: string;
   created_at?: string;
 }
 


### PR DESCRIPTION
## Summary
- normalize captured payload metadata before persisting to Supabase
- store captured records with created_at/session information and return the inserted rows
- hydrate local lead and bonus signup objects with Supabase record data for downstream analytics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3e3fb0d1083288d3b5309623a95d8