### PR TITLE
Add backend endpoint support for lead capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,44 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Why aren't my leads or contacts showing up in Supabase?
+
+Leads, bonus signups, and analytics events are now routed through a dedicated
+data capture endpoint before falling back to direct Supabase writes. This makes
+it possible to use Bolt New (or any other backend) to capture submissions and
+hydrate your Supabase tables server-side.
+
+Here's the order of operations:
+
+1. **Backend endpoint (`VITE_DATA_CAPTURE_ENDPOINT`)** – If configured, every
+   submission is posted to this URL first. The endpoint is expected to relay the
+   payload to Supabase (or any other persistence layer) and return the stored
+   record. This is the recommended way to integrate with Bolt New backend
+   functions.
+2. **Direct Supabase client** – If the backend endpoint is unavailable and the
+   browser has a valid Supabase configuration, the app falls back to writing
+   directly with the Supabase JavaScript client.
+3. **Other transports** – Google Sheets, webhooks, Formspree, Netlify forms,
+   and finally localStorage remain as additional fallbacks so no submission is
+   lost.
+
+### Required environment variables
+
+Add the following entries to your `.env` file (or hosting provider):
+
+```bash
+# Primary Bolt New / custom backend endpoint
+VITE_DATA_CAPTURE_ENDPOINT=https://your-bolt-new-function-url
+
+# Direct Supabase access (used as fallback)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+With these values in place the app can persist leads and contacts through your
+Bolt New backend functions while still retaining the enhanced client-side
+fallbacks.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/0f2329e5-71cc-4ed7-b9ad-7622f15b75de) and click on Share -> Publish.

--- a/src/lib/dataCapture.ts
+++ b/src/lib/dataCapture.ts
@@ -71,8 +71,8 @@ export class OnlineDataCapture {
 
   constructor(options: { enableTracking?: boolean } = {}) {
     this.sessionId = this.generateSessionId();
-    // You can configure this to point to your preferred service
-    this.apiEndpoint = import.meta.env.VITE_DATA_CAPTURE_ENDPOINT || 'https://api.example.com/capture';
+    const endpoint = import.meta.env.VITE_DATA_CAPTURE_ENDPOINT;
+    this.apiEndpoint = typeof endpoint === 'string' ? endpoint.trim() : '';
     this.trackingEnabled = options.enableTracking ?? true;
     if (this.trackingEnabled) {
       this.setupPageTracking();
@@ -154,13 +154,22 @@ export class OnlineDataCapture {
     console.log('🚀 sendData payload:', JSON.stringify(payload, null, 2));
     console.log('🚀 sendData payload.data:', JSON.stringify(payload.data, null, 2));
 
-    const services = [
-      this.sendToSupabase.bind(this),
+    const services: Array<(payload: any) => Promise<any>> = [];
+
+    if (this.apiEndpoint) {
+      services.push(this.sendToBackend.bind(this));
+    }
+
+    if (isSupabaseConfigured && supabase) {
+      services.push(this.sendToSupabase.bind(this));
+    }
+
+    services.push(
       this.sendToGoogleSheets.bind(this),
       this.sendToWebhook.bind(this),
       this.sendToFormspree.bind(this),
       this.sendToNetlifyForms.bind(this)
-    ];
+    );
 
     const formatServiceName = (serviceFn: (payload: any) => Promise<void>) =>
       serviceFn.name?.replace(/^bound\s+/, '') || 'unknown';
@@ -168,11 +177,12 @@ export class OnlineDataCapture {
     const errors: Array<{ service: string; error: unknown }> = [];
 
     let success = false;
+    let serviceResult: unknown = null;
     for (const service of services) {
       const serviceName = formatServiceName(service);
       try {
         console.log('🚀 Trying service:', serviceName);
-        await service(payload);
+        serviceResult = await service(payload);
         console.log('✅ Service succeeded:', serviceName);
         success = true;
         break; // If one succeeds, we're good
@@ -217,6 +227,42 @@ export class OnlineDataCapture {
         throw new DataCaptureSubmissionError(`${baseMessage}${reasonDetails}`, context);
       }
     }
+
+    return serviceResult ?? payload;
+  }
+
+  private extractSupabaseMetadata(payload: any) {
+    const rawTimestamp =
+      (payload?.data && typeof payload.data === 'object' && 'timestamp' in payload.data)
+        ? Number((payload.data as { timestamp?: number | string }).timestamp)
+        : undefined;
+
+    const fallbackTimestamp = typeof rawTimestamp === 'number' && !Number.isNaN(rawTimestamp)
+      ? rawTimestamp
+      : typeof rawTimestamp === 'string' && rawTimestamp
+        ? Date.parse(rawTimestamp)
+        : undefined;
+
+    const timestampToUse = fallbackTimestamp ?? (typeof payload?.timestamp === 'number' ? payload.timestamp : Date.now());
+
+    const toIsoString = (value?: number) => {
+      if (!value || Number.isNaN(value)) return undefined;
+      try {
+        return new Date(value).toISOString();
+      } catch (error) {
+        console.warn('⚠️ Failed to convert timestamp to ISO string:', error);
+        return undefined;
+      }
+    };
+
+    const metadata = {
+      session_id: payload?.sessionId ?? payload?.data?.sessionId,
+      page_url: payload?.data?.pageUrl ?? payload?.url,
+      user_agent: payload?.data?.userAgent ?? payload?.userAgent,
+      created_at: toIsoString(timestampToUse),
+    };
+
+    return metadata;
   }
 
   private async sendToSupabase(payload: any) {
@@ -227,6 +273,8 @@ export class OnlineDataCapture {
     }
 
     try {
+      const metadata = this.extractSupabaseMetadata(payload);
+
       if (payload.type === 'lead') {
         const leadData: LeadRecord = {
           first_name: payload.data.firstName,
@@ -236,27 +284,40 @@ export class OnlineDataCapture {
           package_selected: payload.data.packageBought,
           grade_selected: payload.data.gradeSelected || 'not_specified',
           source: payload.data.source || 'website',
-          session_id: payload.sessionId,
+          ...(metadata.session_id ? { session_id: metadata.session_id } : {}),
+          ...(metadata.page_url ? { page_url: metadata.page_url } : {}),
+          ...(metadata.user_agent ? { user_agent: metadata.user_agent } : {}),
+          ...(metadata.created_at ? { created_at: metadata.created_at } : {}),
         };
 
-        const { error } = await supabase
+        const { data: insertedLead, error } = await supabase
           .from('leads')
-          .insert([leadData]);
+          .insert([leadData])
+          .select()
+          .single();
 
         if (error) throw error;
         console.log('✅ Lead saved to Supabase');
+        return insertedLead;
       } else if (payload.type === 'bonus_signup') {
         const signupData: BonusSignupRecord = {
           email: payload.data.email,
-          session_id: payload.sessionId,
+          source: payload.data.source || 'bonus_page',
+          ...(metadata.session_id ? { session_id: metadata.session_id } : {}),
+          ...(metadata.page_url ? { page_url: metadata.page_url } : {}),
+          ...(metadata.user_agent ? { user_agent: metadata.user_agent } : {}),
+          ...(metadata.created_at ? { created_at: metadata.created_at } : {}),
         };
 
-        const { error } = await supabase
+        const { data: insertedSignup, error } = await supabase
           .from('bonus_signups')
-          .insert([signupData]);
+          .insert([signupData])
+          .select()
+          .single();
 
         if (error) throw error;
         console.log('✅ Bonus signup saved to Supabase');
+        return insertedSignup;
       } else if (payload.type === 'analytics_event') {
         const eventData: AnalyticsEventRecord = {
           event_name: payload.data.eventName,
@@ -265,14 +326,18 @@ export class OnlineDataCapture {
           user_id: payload.data.userId,
           page_url: payload.url,
           user_agent: payload.userAgent,
+          ...(metadata.created_at ? { created_at: metadata.created_at } : {}),
         };
 
-        const { error } = await supabase
+        const { data: insertedEvent, error } = await supabase
           .from('analytics_events')
-          .insert([eventData]);
+          .insert([eventData])
+          .select()
+          .single();
 
         if (error) throw error;
         console.log('✅ Analytics event saved to Supabase');
+        return insertedEvent;
       } else if (payload.type === 'page_view' || payload.type === 'page_visit' || payload.type === 'page_visit_end') {
         const eventData: AnalyticsEventRecord = {
           event_name: payload.type,
@@ -280,18 +345,73 @@ export class OnlineDataCapture {
           session_id: payload.sessionId,
           page_url: payload.url,
           user_agent: payload.userAgent,
+          ...(metadata.created_at ? { created_at: metadata.created_at } : {}),
         };
 
-        const { error } = await supabase
+        const { data: insertedPageEvent, error } = await supabase
           .from('analytics_events')
-          .insert([eventData]);
+          .insert([eventData])
+          .select()
+          .single();
 
         if (error) throw error;
         console.log('✅ Page visit saved to Supabase');
+        return insertedPageEvent;
       }
     } catch (error) {
       console.error('❌ Supabase error:', error);
       throw new Error(`Supabase failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async sendToBackend(payload: any) {
+    if (!this.apiEndpoint) {
+      throw new Error('No data capture endpoint configured');
+    }
+
+    console.log('🌐 Sending payload to backend endpoint:', this.apiEndpoint);
+
+    try {
+      const response = await fetch(this.apiEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      let parsed: any = null;
+      let fallbackText: string | null = null;
+
+      try {
+        parsed = await response.clone().json();
+      } catch (parseError) {
+        console.warn('⚠️ Backend response was not JSON, falling back to text parse:', parseError);
+        fallbackText = await response.text();
+      }
+
+      if (!response.ok) {
+        const errorMessage =
+          (parsed && typeof parsed === 'object' && 'error' in parsed && typeof parsed.error === 'string'
+            ? parsed.error
+            : null) || fallbackText || `HTTP ${response.status}`;
+        throw new Error(`Backend endpoint failed: ${errorMessage}`);
+      }
+
+      if (parsed && typeof parsed === 'object') {
+        const normalized =
+          'record' in parsed && parsed.record
+            ? parsed.record
+            : 'data' in parsed && parsed.data
+              ? parsed.data
+              : parsed;
+        return normalized;
+      }
+
+      return fallbackText ?? null;
+    } catch (error) {
+      console.error('❌ Backend endpoint error:', error);
+      throw error;
     }
   }
 
@@ -434,7 +554,22 @@ export class OnlineDataCapture {
     };
 
     console.log('🔥 Prepared lead object:', lead);
-    await this.sendData('lead', lead);
+    const supabaseLead = await this.sendData('lead', lead);
+    if (supabaseLead && typeof supabaseLead === 'object') {
+      const record = supabaseLead as Partial<LeadRecord>;
+      if (record.id) {
+        lead.id = record.id;
+      }
+      if (record.session_id) {
+        lead.sessionId = record.session_id;
+      }
+      if (record.page_url) {
+        lead.pageUrl = record.page_url;
+      }
+      if (record.user_agent) {
+        lead.userAgent = record.user_agent;
+      }
+    }
     console.log('🔥 Lead sent to sendData');
     return lead;
   }
@@ -453,7 +588,22 @@ export class OnlineDataCapture {
     };
 
     console.log('🔥 Prepared bonus signup object:', signup);
-    await this.sendData('bonus_signup', signup);
+    const supabaseSignup = await this.sendData('bonus_signup', signup);
+    if (supabaseSignup && typeof supabaseSignup === 'object') {
+      const record = supabaseSignup as Partial<BonusSignupRecord>;
+      if (record.id) {
+        signup.id = record.id;
+      }
+      if (record.session_id) {
+        signup.sessionId = record.session_id;
+      }
+      if (record.page_url) {
+        signup.pageUrl = record.page_url;
+      }
+      if (record.user_agent) {
+        signup.userAgent = record.user_agent;
+      }
+    }
     console.log('🔥 Bonus signup sent to sendData');
     return signup;
   }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -25,6 +25,8 @@ export interface LeadRecord {
   grade_selected: string;
   source?: string;
   session_id?: string;
+  page_url?: string;
+  user_agent?: string;
   created_at?: string;
 }
 
@@ -32,6 +34,9 @@ export interface BonusSignupRecord {
   id?: string;
   email: string;
   session_id?: string;
+  source?: string;
+  page_url?: string;
+  user_agent?: string;
   created_at?: string;
 }
 


### PR DESCRIPTION
## Summary
- send form payloads to a configurable backend endpoint before trying Supabase or other fallbacks
- add resilient parsing and error handling for the backend transport
- document the new VITE_DATA_CAPTURE_ENDPOINT configuration alongside Supabase setup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3e3fb0d1083288d3b5309623a95d8