### PR TITLE
Normalize Supabase environment URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ Add the following entries to your `.env` file (or hosting provider):
 VITE_DATA_CAPTURE_ENDPOINT=https://your-bolt-new-function-url
 
 # Direct Supabase access (used as fallback)
+# The app now also reads `SUPABASE_URL` and `SUPABASE_ANON_KEY` so you can
+# reuse the credentials provided by Supabase hosting without renaming them.
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 ```
+
+> **Tip:** Supabase hosting sometimes injects values wrapped in quotes (for
+> example `"https://xyz.supabase.co"`). The app now trims these automatically,
+> but you should verify the stored values do not include extra quotes or
+> whitespace so the browser can resolve the domain correctly.
 
 With these values in place the app can persist leads and contacts through your
 Bolt New backend functions while still retaining the enhanced client-side

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,64 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+const sanitizeEnvValue = (value?: string): string => {
+  if (typeof value !== 'string') return '';
 
-const hasSupabaseConfig = supabaseUrl && supabaseAnonKey;
+  let trimmed = value.trim();
+  if (!trimmed) return '';
+  if (trimmed === 'undefined' || trimmed === 'null') return '';
+
+  const firstChar = trimmed.charAt(0);
+  const lastChar = trimmed.charAt(trimmed.length - 1);
+  const matchingQuotes =
+    (firstChar === lastChar && ['"', "'", '`'].includes(firstChar)) ||
+    (firstChar === '“' && lastChar === '”') ||
+    (firstChar === '”' && lastChar === '“');
+
+  if (matchingQuotes) {
+    trimmed = trimmed.slice(1, -1).trim();
+  }
+
+  return trimmed;
+};
+
+const validateSupabaseUrl = (value: string): string => {
+  if (!value) return '';
+
+  try {
+    const parsed = new URL(value);
+
+    if (!/^https?:$/.test(parsed.protocol)) {
+      throw new Error(`Unsupported protocol: ${parsed.protocol}`);
+    }
+
+    return parsed.origin;
+  } catch (error) {
+    console.error(
+      'Supabase URL environment variable is invalid and will be ignored. Received value:',
+      value,
+      error
+    );
+    return '';
+  }
+};
+
+const rawSupabaseUrl =
+  sanitizeEnvValue(import.meta.env.VITE_SUPABASE_URL) ||
+  sanitizeEnvValue(import.meta.env.SUPABASE_URL);
+
+const supabaseUrl = validateSupabaseUrl(rawSupabaseUrl);
+
+const supabaseAnonKey =
+  sanitizeEnvValue(import.meta.env.VITE_SUPABASE_ANON_KEY) ||
+  sanitizeEnvValue(import.meta.env.SUPABASE_ANON_KEY);
+
+if (rawSupabaseUrl && !supabaseUrl) {
+  console.warn(
+    'Supabase URL was provided but is not a valid https URL. Check for extra quotes or typos in your environment configuration.'
+  );
+}
+
+const hasSupabaseConfig = supabaseUrl !== '' && supabaseAnonKey !== '';
 
 if (!hasSupabaseConfig) {
   console.warn('Supabase environment variables not configured. Database features will be disabled.');

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+  readonly SUPABASE_URL?: string;
+  readonly SUPABASE_ANON_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,4 +31,5 @@ export default defineConfig(({ mode }) => ({
   test: {
     environment: "jsdom",
   },
+  envPrefix: ["VITE_", "SUPABASE_"],
 }));


### PR DESCRIPTION
## Summary
- strip quotes and whitespace from Supabase environment variables before using them in the client
- validate the resolved Supabase URL and warn when it is invalid so deployments catch DNS typos early
- document the quoting caveat for Supabase-provided environment values in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e41c3249d883288013eb30598045d6